### PR TITLE
Persist all messages in a chat

### DIFF
--- a/src/MockBot.Api/Controllers/ChatController.cs
+++ b/src/MockBot.Api/Controllers/ChatController.cs
@@ -65,11 +65,16 @@ namespace MockBot.Api.Controllers
                     content = await reader.ReadToEndAsync().ConfigureAwait(false);
                 }
 
+                if (string.IsNullOrEmpty(content))
+                {
+                    return new BadRequestObjectResult("Post must have a body");
+                }
+
                 var headers = new HeadersInput()
                 {
                     XSentBy = _settings.Id,
-                    XSendTo = "Dmr",
-                    XModelType = "application/vnd.classifier.classification+json;version=1",
+                    XSendTo = Models.Constants.XSendToDmr,
+                    XModelType = Models.Constants.XModelType,
                 };
 
                 var message = _chatService.AddMessage(chatId, content, headers);
@@ -96,10 +101,10 @@ namespace MockBot.Api.Controllers
             var dmrHeaders = new HeadersInput
             {
                 XSentBy = botId,
-                XSendTo = "Classifier",
+                XSendTo = Models.Constants.XSendToClassifier,
                 XMessageId = message.Id.ToString(),
-                XModelType = "application/vnd.classifier.classification+json;version=1",
-                ContentType = "text/plain"
+                XModelType = Models.Constants.XModelType,
+                ContentType = Models.Constants.ContentTypePlain
             };
 
             // Setup payload

--- a/src/MockBot.Api/Controllers/ChatController.cs
+++ b/src/MockBot.Api/Controllers/ChatController.cs
@@ -77,7 +77,7 @@ namespace MockBot.Api.Controllers
                 var message = _chatService.AddMessage(chatId, content, headers);
                 _chatService.AddDmrRequest(message);
 
-                _dmrService.Enqueue(GetDmrRequest(message, Models.Constants.Empty, _settings.Id));
+                _dmrService.Enqueue(GetDmrRequest(message, _settings.Id));
                 return Created(new Uri($"/chats/{chatId}/messages", UriKind.Relative), message);
             }
             catch (ArgumentOutOfRangeException)
@@ -92,7 +92,7 @@ namespace MockBot.Api.Controllers
         /// <param name="message">The message to go into the .Payload.Message property</param>
         /// <param name="classification">No classification before getting send to DMR</param>
         /// <returns>A DmrRequest object</returns>
-        private static DmrRequest GetDmrRequest(ChatMessage message, string classification, string botId)
+        private static DmrRequest GetDmrRequest(ChatMessage message, string botId, string classification = default)
         {
             // Setup headers
             var dmrHeaders = new HeadersInput
@@ -108,7 +108,7 @@ namespace MockBot.Api.Controllers
             var dmrPayload = new DmrRequestPayload()
             {
                 Message = message.Content,
-                Classification = classification
+                Classification = string.IsNullOrEmpty(classification) ? string.Empty : classification
             };
 
             // Setup request

--- a/src/MockBot.Api/Controllers/ChatController.cs
+++ b/src/MockBot.Api/Controllers/ChatController.cs
@@ -59,7 +59,7 @@ namespace MockBot.Api.Controllers
         {
             try
             {
-                string content;
+                string content = string.Empty;
                 using (StreamReader reader = new(Request.Body, Encoding.UTF8))
                 {
                     content = await reader.ReadToEndAsync().ConfigureAwait(false);

--- a/src/MockBot.Api/Controllers/ChatController.cs
+++ b/src/MockBot.Api/Controllers/ChatController.cs
@@ -64,7 +64,7 @@ namespace MockBot.Api.Controllers
 
                 if (string.IsNullOrEmpty(content))
                 {
-                    return new BadRequestObjectResult("Post must have a body");
+                    return new BadRequestObjectResult(Models.Constants.PostNoBodyMessage);
                 }
 
                 var headers = new HeadersInput()

--- a/src/MockBot.Api/Controllers/ChatController.cs
+++ b/src/MockBot.Api/Controllers/ChatController.cs
@@ -65,7 +65,14 @@ namespace MockBot.Api.Controllers
                     content = await reader.ReadToEndAsync().ConfigureAwait(false);
                 }
 
-                var message = _chatService.AddMessage(chatId, content);
+                var headers = new HeadersInput()
+                {
+                    XSentBy = _settings.Id,
+                    XSendTo = "Dmr",
+                    XModelType = "application/vnd.classifier.classification+json;version=1",
+                };
+
+                var message = _chatService.AddMessage(chatId, content, headers);
                 _chatService.AddDmrRequest(message);
 
                 _dmrService.Enqueue(GetDmrRequest(message, string.Empty, _settings.Id));

--- a/src/MockBot.Api/Controllers/ChatController.cs
+++ b/src/MockBot.Api/Controllers/ChatController.cs
@@ -59,11 +59,8 @@ namespace MockBot.Api.Controllers
         {
             try
             {
-                string content = string.Empty;
-                using (StreamReader reader = new(Request.Body, Encoding.UTF8))
-                {
-                    content = await reader.ReadToEndAsync().ConfigureAwait(false);
-                }
+                using StreamReader reader = new(Request.Body, Encoding.UTF8);
+                string content = await reader.ReadToEndAsync().ConfigureAwait(false);
 
                 if (string.IsNullOrEmpty(content))
                 {
@@ -80,7 +77,7 @@ namespace MockBot.Api.Controllers
                 var message = _chatService.AddMessage(chatId, content, headers);
                 _chatService.AddDmrRequest(message);
 
-                _dmrService.Enqueue(GetDmrRequest(message, string.Empty, _settings.Id));
+                _dmrService.Enqueue(GetDmrRequest(message, Models.Constants.Empty, _settings.Id));
                 return Created(new Uri($"/chats/{chatId}/messages", UriKind.Relative), message);
             }
             catch (ArgumentOutOfRangeException)

--- a/src/MockBot.Api/Controllers/DmrController.cs
+++ b/src/MockBot.Api/Controllers/DmrController.cs
@@ -44,8 +44,9 @@ namespace MockBot.Api.Controllers
                 var chat = _chatService.FindByMessageId(new Guid(headers?.XMessageIdRef));
                 if (chat == null)
                 {
-                    // No matching message, create a new chat
+                    // No matching message, create a new chat and log a warning
                     chat = _chatService.CreateChat();
+                    _logger.MessageWithNoChatReceived(headers?.XMessageIdRef, chat.Id.ToString(), encodedPayload, decodedPayload);
                 }
 
                 _ = _chatService.AddMessage(chat.Id, payload.Message, headers, payload.Classification);

--- a/src/MockBot.Api/Controllers/DmrController.cs
+++ b/src/MockBot.Api/Controllers/DmrController.cs
@@ -42,6 +42,12 @@ namespace MockBot.Api.Controllers
 
                 // Add the message to the chat
                 var chat = _chatService.FindByMessageId(new Guid(headers?.XMessageIdRef));
+                if (chat == null)
+                {
+                    // No matching message, create a new chat
+                    chat = _chatService.CreateChat();
+                }
+
                 _ = _chatService.AddMessage(chat.Id, payload.Message, headers, payload.Classification);
 
                 // Log telemtary

--- a/src/MockBot.Api/Controllers/DmrController.cs
+++ b/src/MockBot.Api/Controllers/DmrController.cs
@@ -52,14 +52,14 @@ namespace MockBot.Api.Controllers
 
                 // Log telemtary
                 _logger.DmrCallbackReceived(
-                    headers?.XSentBy ?? "Unknown",
-                    headers?.XMessageIdRef ?? "Unknown",
+                    headers?.XSentBy ?? Models.Constants.Unknown,
+                    headers?.XMessageIdRef ?? Models.Constants.Unknown,
                     encodedPayload,
                     decodedPayload);
             }
             catch (ArgumentException)
             {
-                return NotFound(headers?.XMessageIdRef ?? "Unknown");
+                return NotFound(headers?.XMessageIdRef ?? Models.Constants.Unknown);
             }
 
             return Accepted();

--- a/src/MockBot.Api/Controllers/Extensions/LoggerExtensions.cs
+++ b/src/MockBot.Api/Controllers/Extensions/LoggerExtensions.cs
@@ -8,9 +8,20 @@
                 new EventId(1, nameof(DmrCallbackReceived)),
                 "Received Dmr Callback from '{From}' regarding '{MessageRef}' {Encoded} {Decoded}");
 
+        private static readonly Action<ILogger, string, string, string, string, Exception> _messageWithNoChatReceived =
+            LoggerMessage.Define<string, string, string, string>(
+                LogLevel.Warning,
+                new EventId(1, nameof(DmrCallbackReceived)),
+                "Received a Message from Dmr where the ChatId ('{NotFoundChatid}' could not be found. Have created a new chat ('{NewChatId}') and assigned the Message to it. {Encoded} {Decoded}");
+
         public static void DmrCallbackReceived(this ILogger logger, string from, string messageRef, string encodedPayload, string decodedPayload)
         {
             _dmrCallbackReceived(logger, from, messageRef, encodedPayload, decodedPayload, null);
+        }
+
+        public static void MessageWithNoChatReceived(this ILogger logger, string notFoundChatid, string newChatId, string encodedPayload, string decodedPayload)
+        {
+            _messageWithNoChatReceived(logger, notFoundChatid, newChatId, encodedPayload, decodedPayload, null);
         }
     }
 }

--- a/src/MockBot.Api/Interfaces/IChatService.cs
+++ b/src/MockBot.Api/Interfaces/IChatService.cs
@@ -16,10 +16,10 @@ namespace MockBot.Api.Interfaces
 
         public Chat FindById(Guid chatId);
 
-        public ChatMessage AddMessage(Guid chatId, string content);
+        public Chat FindByMessageId(Guid chatMessageId);
+
+        public ChatMessage AddMessage(Guid chatId, string content, HeadersInput headers, string classification = default);
 
         public void AddDmrRequest(ChatMessage message);
-
-        public void AddMessageMetadata(HeadersInput headers);
     }
 }

--- a/src/MockBot.Api/Models/ChatMessage.cs
+++ b/src/MockBot.Api/Models/ChatMessage.cs
@@ -15,6 +15,8 @@ namespace MockBot.Api.Models
 
         public string Content { get; }
 
+        public string Classification { get; set; }
+
         public DateTime CreatedAt { get; } = DateTime.UtcNow;
 
         public string ModelType { get; set; }

--- a/src/MockBot.Api/Models/ChatMessage.cs
+++ b/src/MockBot.Api/Models/ChatMessage.cs
@@ -3,10 +3,10 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace MockBot.Api.Models
 {
+    // No logic so no unit tests are required
+    [ExcludeFromCodeCoverage]
     public class ChatMessage
     {
-        // No logic so no unit tests are required
-        [ExcludeFromCodeCoverage]
         public Guid Id { get; } = Guid.NewGuid();
 
         public string SentBy { get; set; }

--- a/src/MockBot.Api/Models/Constants.cs
+++ b/src/MockBot.Api/Models/Constants.cs
@@ -11,6 +11,5 @@ namespace MockBot.Api.Models
         public const string XSendToClassifier = "Classifier";
         public const string XModelType = "application/vnd.classifier.classification+json;version=1";
         public const string ContentTypePlain = "text/plain";
-        public const string Empty = "";
     }
 }

--- a/src/MockBot.Api/Models/Constants.cs
+++ b/src/MockBot.Api/Models/Constants.cs
@@ -11,5 +11,6 @@ namespace MockBot.Api.Models
         public const string XSendToClassifier = "Classifier";
         public const string XModelType = "application/vnd.classifier.classification+json;version=1";
         public const string ContentTypePlain = "text/plain";
+        public const string PostNoBodyMessage = "Post must have a body";
     }
 }

--- a/src/MockBot.Api/Models/Constants.cs
+++ b/src/MockBot.Api/Models/Constants.cs
@@ -7,5 +7,9 @@ namespace MockBot.Api.Models
     public static class Constants
     {
         public const string Unknown = "Unknown";
+        public const string XSendToDmr = "Dmr";
+        public const string XSendToClassifier = "Classifier";
+        public const string XModelType = "application/vnd.classifier.classification+json;version=1";
+        public const string ContentTypePlain = "text/plain";
     }
 }

--- a/src/MockBot.Api/Models/Constants.cs
+++ b/src/MockBot.Api/Models/Constants.cs
@@ -1,0 +1,11 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace MockBot.Api.Models
+{
+    // No logic so no unit tests are required
+    [ExcludeFromCodeCoverage]
+    public static class Constants
+    {
+        public const string Unknown = "Unknown";
+    }
+}

--- a/src/MockBot.Api/Models/Constants.cs
+++ b/src/MockBot.Api/Models/Constants.cs
@@ -11,5 +11,6 @@ namespace MockBot.Api.Models
         public const string XSendToClassifier = "Classifier";
         public const string XModelType = "application/vnd.classifier.classification+json;version=1";
         public const string ContentTypePlain = "text/plain";
+        public const string Empty = "";
     }
 }

--- a/src/MockBot.UnitTests/Controllers/ChatControllerTests.cs
+++ b/src/MockBot.UnitTests/Controllers/ChatControllerTests.cs
@@ -8,7 +8,6 @@ using MockBot.Api.Services;
 using Moq;
 using RequestProcessor.AsyncProcessor;
 using RequestProcessor.Dmr;
-using RequestProcessor.Models;
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/MockBot.UnitTests/Controllers/ChatControllerTests.cs
+++ b/src/MockBot.UnitTests/Controllers/ChatControllerTests.cs
@@ -129,11 +129,12 @@ namespace MockBot.UnitTests.Controllers
             var chatId = Guid.NewGuid();
 
             // Act
-            BadRequestObjectResult result = (BadRequestObjectResult)await _sut.PostMessageAsync(chatId).ConfigureAwait(false);
+            var result = await _sut.PostMessageAsync(chatId).ConfigureAwait(false);
 
             // Assert
             _ = Assert.IsType<BadRequestObjectResult>(result);
-            Assert.Equal("Post must have a body", result.Value);
+            var resultBadRequest = result as BadRequestObjectResult;
+            Assert.Equal("Post must have a body", resultBadRequest.Value);
         }
 
         private static DefaultHttpContext GetContext(string payload)

--- a/src/MockBot.UnitTests/Controllers/ChatControllerTests.cs
+++ b/src/MockBot.UnitTests/Controllers/ChatControllerTests.cs
@@ -119,6 +119,23 @@ namespace MockBot.UnitTests.Controllers
             _ = Assert.IsType<NotFoundObjectResult>(result);
         }
 
+        [Fact]
+        public async Task ShouldReturnBadReqestIfBodyEmpty()
+        {
+            // Arrange
+            _sut.ControllerContext = new ControllerContext()
+            {
+                HttpContext = GetContext(string.Empty)
+            };
+            var chatId = Guid.NewGuid();
+
+            // Act
+            var result = await _sut.PostMessageAsync(chatId).ConfigureAwait(false);
+
+            // Assert
+            _ = Assert.IsType<BadRequestObjectResult>(result);
+        }
+
         private static DefaultHttpContext GetContext(string payload)
         {
             var httpContext = new DefaultHttpContext();

--- a/src/MockBot.UnitTests/Controllers/ChatControllerTests.cs
+++ b/src/MockBot.UnitTests/Controllers/ChatControllerTests.cs
@@ -21,23 +21,14 @@ namespace MockBot.UnitTests.Controllers
     public class ChatControllerTests : ControllerBase
     {
         private readonly ChatController _sut;
-        private readonly Mock<IChatService> _mockChatService;
         private readonly IChatService _chatService;
         private readonly Mock<IAsyncProcessorService<DmrRequest>> _mockDmrService;
-        private readonly HeadersInput _headers;
 
         public ChatControllerTests()
         {
-            _mockChatService = new Mock<IChatService>();
             _chatService = new ChatService();
             _mockDmrService = new Mock<IAsyncProcessorService<DmrRequest>>();
             _sut = new ChatController(_chatService, _mockDmrService.Object, new BotSettings() { Id = "unitTestBot" });
-            _headers = new HeadersInput
-            {
-                XSentBy = "unitTestBot",
-                XSendTo = "receiver",
-                XModelType = "somemodel"
-            };
         }
 
         [Fact]

--- a/src/MockBot.UnitTests/Controllers/ChatControllerTests.cs
+++ b/src/MockBot.UnitTests/Controllers/ChatControllerTests.cs
@@ -130,10 +130,11 @@ namespace MockBot.UnitTests.Controllers
             var chatId = Guid.NewGuid();
 
             // Act
-            var result = await _sut.PostMessageAsync(chatId).ConfigureAwait(false);
+            BadRequestObjectResult result = (BadRequestObjectResult)await _sut.PostMessageAsync(chatId).ConfigureAwait(false);
 
             // Assert
             _ = Assert.IsType<BadRequestObjectResult>(result);
+            Assert.Equal("Post must have a body", result.Value);
         }
 
         private static DefaultHttpContext GetContext(string payload)

--- a/src/MockBot.UnitTests/Controllers/ChatControllerTests.cs
+++ b/src/MockBot.UnitTests/Controllers/ChatControllerTests.cs
@@ -44,10 +44,7 @@ namespace MockBot.UnitTests.Controllers
         public void ShouldReturnSingleChat()
         {
             // Arrange
-            var chat = new Chat();
-            _ = _mockChatService.Setup(mock => mock.CreateChat())
-                .Returns(chat);
-            _ = _mockChatService.Setup(mock => mock.FindById(chat.Id)).Returns(chat);
+            var chat = _chatService.CreateChat();
 
             // Act
             var response = _sut.Get(chat.Id);
@@ -61,13 +58,14 @@ namespace MockBot.UnitTests.Controllers
         [Fact]
         public void ShouldReturnAllChats()
         {
-            var chat1 = new Chat();
-            var chat2 = new Chat();
-            var mockChats = new List<Chat>() { chat1, chat2 };
-            _ = _mockChatService.Setup(mock => mock.FindAll()).Returns(mockChats);
+            // Arrange
+            var chat1 = _chatService.CreateChat();
+            var chat2 = _chatService.CreateChat();
 
+            // Act
             var result = _sut.FindAll();
 
+            // Assert
             Assert.Equal(200, result.StatusCode);
             var resultList = Assert.IsType<List<Chat>>(result.Value);
             Assert.Equal(2, resultList.Count);
@@ -78,11 +76,10 @@ namespace MockBot.UnitTests.Controllers
         [Fact]
         public void ShouldCreateAndReturnChat()
         {
-            var chat = new Chat();
-            _ = _mockChatService.Setup(mock => mock.CreateChat()).Returns(chat);
-
+            // Act
             var result = _sut.Post();
 
+            // Assert
             Assert.Equal(201, result.StatusCode);
             var resultChat = Assert.IsType<Chat>(result.Value);
             Assert.NotEmpty(resultChat.Id.ToString());

--- a/src/MockBot.UnitTests/Controllers/ChatControllerTests.cs
+++ b/src/MockBot.UnitTests/Controllers/ChatControllerTests.cs
@@ -134,7 +134,7 @@ namespace MockBot.UnitTests.Controllers
             // Assert
             _ = Assert.IsType<BadRequestObjectResult>(result);
             var resultBadRequest = result as BadRequestObjectResult;
-            Assert.Equal("Post must have a body", resultBadRequest.Value);
+            Assert.Equal(Constants.PostNoBodyMessage, resultBadRequest.Value);
         }
 
         private static DefaultHttpContext GetContext(string payload)

--- a/src/MockBot.UnitTests/Controllers/ChatControllerTests.cs
+++ b/src/MockBot.UnitTests/Controllers/ChatControllerTests.cs
@@ -7,6 +7,7 @@ using MockBot.Api.Models;
 using Moq;
 using RequestProcessor.AsyncProcessor;
 using RequestProcessor.Dmr;
+using RequestProcessor.Models;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -22,12 +23,21 @@ namespace MockBot.UnitTests.Controllers
         private readonly ChatController _sut;
         private readonly Mock<IChatService> _mockChatService;
         private readonly Mock<IAsyncProcessorService<DmrRequest>> _mockDmrService;
+        private readonly HeadersInput _headers;
 
         public ChatControllerTests()
         {
             _mockChatService = new Mock<IChatService>();
             _mockDmrService = new Mock<IAsyncProcessorService<DmrRequest>>();
             _sut = new ChatController(_mockChatService.Object, _mockDmrService.Object, new BotSettings() { Id = "bot1" });
+            _headers = new HeadersInput
+            {
+                XSentBy = "sender",
+                XSendTo = "receiver",
+                XMessageId = "UnitTestMessage",
+                XMessageIdRef = "",
+                XModelType = "somemodel"
+            };
         }
 
         [Fact]
@@ -91,7 +101,7 @@ namespace MockBot.UnitTests.Controllers
             var message = new ChatMessage(payload);
             var chat = new Chat();
             var currentDateTime = new DateTime();
-            _ = _mockChatService.Setup(mock => mock.AddMessage(chat.Id, payload)).Returns(message);
+            _ = _mockChatService.Setup(mock => mock.AddMessage(chat.Id, payload, _headers, default)).Returns(message);
 
             var result = await _sut.PostMessageAsync(chat.Id).ConfigureAwait(false);
 
@@ -113,7 +123,7 @@ namespace MockBot.UnitTests.Controllers
                 HttpContext = GetContext(payload)
             };
             var chat = new Chat();
-            _ = _mockChatService.Setup(mock => mock.AddMessage(chat.Id, payload)).Throws(new ArgumentOutOfRangeException(chat.Id.ToString()));
+            _ = _mockChatService.Setup(mock => mock.AddMessage(chat.Id, payload, _headers, default)).Throws(new ArgumentOutOfRangeException(chat.Id.ToString()));
 
 
             var result = await _sut.PostMessageAsync(chat.Id).ConfigureAwait(false);

--- a/src/MockBot.UnitTests/Controllers/DmrControllerTests.cs
+++ b/src/MockBot.UnitTests/Controllers/DmrControllerTests.cs
@@ -17,39 +17,6 @@ namespace MockBot.UnitTests.Controllers
     public class DmrControllerTests
     {
         [Fact]
-        public async Task ShouldReturnAcceptedAndAddMetadataToMessageAsync()
-        {
-            // Arrange
-            var _mockChatService = new Mock<IChatService>();
-            var _mockEncoderService = new Mock<IEncodingService>();
-            var _logger = new Mock<ILogger<DmrController>>();
-
-            var message = new Message() { Payload = "An important message" };
-            var xSentBy = "sender";
-            var xSendTo = "receiver";
-            var xMessageId = "dmrMessage";
-            var xMessageIdRef = Guid.NewGuid().ToString();
-            var xModelType = "good";
-            var headers = new HeadersInput
-            {
-                XSentBy = xSentBy,
-                XSendTo = xSendTo,
-                XMessageId = xMessageId,
-                XMessageIdRef = xMessageIdRef,
-                XModelType = xModelType
-            };
-
-            var sut = SetupControllerContext(_mockChatService.Object, _mockEncoderService.Object, _logger.Object, "Message");
-
-            // Act
-            var result = await sut.PostDmrMessageAsync(headers).ConfigureAwait(false);
-
-            // Assert
-            _ = Assert.IsType<AcceptedResult>(result);
-            _mockChatService.Verify(cs => cs.AddMessageMetadata(It.IsAny<HeadersInput>()), Times.Once);
-        }
-
-        [Fact]
         public async Task DmrCallbackLogsTheCorrectEvent()
         {
             // Arrange

--- a/src/MockBot.UnitTests/Controllers/DmrControllerTests.cs
+++ b/src/MockBot.UnitTests/Controllers/DmrControllerTests.cs
@@ -1,9 +1,12 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using MockBot.Api.Controllers;
 using MockBot.Api.Interfaces;
+using MockBot.Api.Services;
 using Moq;
+using RequestProcessor.Dmr;
 using RequestProcessor.Models;
 using RequestProcessor.Services.Encoder;
 using System;
@@ -20,11 +23,9 @@ namespace MockBot.UnitTests.Controllers
         public async Task DmrCallbackLogsTheCorrectEvent()
         {
             // Arrange
-            var _mockChatService = new Mock<IChatService>();
-            var _mockEncoderService = new Mock<IEncodingService>();
+            var chatService = new ChatService();
+            var encodingService = new EncodingService();
             var _logger = new Mock<ILogger<DmrController>>();
-
-            var message = new Message() { Payload = "An important message" };
             var xSentBy = "sender";
             var xSendTo = "receiver";
             var xMessageId = "dmrMessage";
@@ -38,8 +39,9 @@ namespace MockBot.UnitTests.Controllers
                 XMessageIdRef = xMessageIdRef,
                 XModelType = xModelType
             };
+            var base64DmrRequestPayload = "ewogICAgIkNsYXNzaWZpY2F0aW9uIjoiZWR1Y2F0aW9uIiwKICAgICJNZXNzYWdlIjoiaSB3YW50IHRvIHJlZ2lzdGVyIG15IGNoaWxkIGF0IHNjaG9vbCIKfQ==";
 
-            var sut = SetupControllerContext(_mockChatService.Object, _mockEncoderService.Object, _logger.Object, "Message");
+            var sut = SetupControllerContext(chatService, encodingService, _logger.Object, base64DmrRequestPayload);
             _ = _logger.Setup(l => l.IsEnabled(It.IsAny<LogLevel>())).Returns(true);
 
             // Act

--- a/src/MockBot.UnitTests/Controllers/DmrControllerTests.cs
+++ b/src/MockBot.UnitTests/Controllers/DmrControllerTests.cs
@@ -1,12 +1,10 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using MockBot.Api.Controllers;
 using MockBot.Api.Interfaces;
 using MockBot.Api.Services;
 using Moq;
-using RequestProcessor.Dmr;
 using RequestProcessor.Models;
 using RequestProcessor.Services.Encoder;
 using System;

--- a/src/MockBot.UnitTests/Services/ChatServiceTests.cs
+++ b/src/MockBot.UnitTests/Services/ChatServiceTests.cs
@@ -18,8 +18,6 @@ namespace MockBot.UnitTests.Services
             {
                 XSentBy = "sender",
                 XSendTo = "receiver",
-                XMessageId = "UnitTestMessage",
-                XMessageIdRef = "",
                 XModelType = "somemodel"
             };
         }

--- a/src/MockBot.UnitTests/Services/ChatServiceTests.cs
+++ b/src/MockBot.UnitTests/Services/ChatServiceTests.cs
@@ -9,10 +9,19 @@ namespace MockBot.UnitTests.Services
     public class ChatServiceTests
     {
         private readonly ChatService _sut;
+        private readonly HeadersInput _headers;
 
         public ChatServiceTests()
         {
             _sut = new ChatService();
+            _headers = new HeadersInput
+            {
+                XSentBy = "sender",
+                XSendTo = "receiver",
+                XMessageId = "UnitTestMessage",
+                XMessageIdRef = "",
+                XModelType = "somemodel"
+            };
         }
 
         [Fact]
@@ -47,7 +56,7 @@ namespace MockBot.UnitTests.Services
             const string messageContent = "someText";
 
             var chat = _sut.CreateChat();
-            _ = _sut.AddMessage(chat.Id, messageContent);
+            _ = _sut.AddMessage(chat.Id, messageContent, _headers);
 
             var result = _sut.FindById(chat.Id);
             _ = Assert.Single(result.Messages);
@@ -64,48 +73,6 @@ namespace MockBot.UnitTests.Services
         }
 
         [Fact]
-        public void ShouldAddMessageMetadata()
-        {
-            var message = new ChatMessage("Hello");
-            var xSentBy = "sender";
-            var xSendTo = "receiver";
-            var xMessageId = "dmrMessage";
-            var xMessageIdRef = message.Id.ToString();
-            var xModelType = "good";
-            _sut.AddDmrRequest(message);
-            var headers = new HeadersInput
-            {
-                XSentBy = xSentBy,
-                XSendTo = xSendTo,
-                XMessageId = xMessageId,
-                XMessageIdRef = xMessageIdRef,
-                XModelType = xModelType
-            };
-
-            _sut.AddMessageMetadata(headers);
-
-            Assert.Equal(xSentBy, message.SentBy);
-            Assert.Equal(xSendTo, message.SendTo);
-            Assert.Equal(xModelType, message.ModelType);
-        }
-
-        [Fact]
-        public void AddMessageMetadataWithNullShouldThrowNullArgument()
-        {
-            // Act & Assert
-            var ex = Assert.Throws<ArgumentNullException>(() => _sut.AddMessageMetadata(null));
-            Assert.Equal("Value cannot be null. (Parameter 'headers')", ex.Message);
-        }
-
-        [Fact]
-        public void AddMessageMetadataMissingMessageRefShouldThrowArgument()
-        {
-            // Act & Assert
-            var ex = Assert.Throws<ArgumentException>(() => _sut.AddMessageMetadata(new HeadersInput() { XMessageIdRef = "Doesn'tExist" }));
-            Assert.Equal("Doesn'tExist", ex.Message);
-        }
-
-        [Fact]
         public void AddDmrRequestWithNullShouldThrowNullArgument()
         {
             // Act & Assert
@@ -117,7 +84,7 @@ namespace MockBot.UnitTests.Services
         public void AddMessageInvalidChatIdShouldThrowArgumentOutOfRangeException()
         {
             // Act & Assert
-            var ex = Assert.Throws<ArgumentOutOfRangeException>(() => _sut.AddMessage(Guid.NewGuid(), "foo"));
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(() => _sut.AddMessage(Guid.NewGuid(), "foo", _headers));
             Assert.Equal("Specified argument was out of the range of valid values. (Parameter 'chatId')", ex.Message);
         }
     }

--- a/src/stryker-config.json
+++ b/src/stryker-config.json
@@ -6,7 +6,7 @@
         "cleartext",
         "html"
       ],
-      "thresholds": { "high": 90, "low": 60, "break": 60 }
+      "thresholds": { "high": 90, "low": 60, "break": 60 },
 	"ignore-methods" : [ "ConfigureAwait" ]
     }  
   }

--- a/src/stryker-config.json
+++ b/src/stryker-config.json
@@ -7,5 +7,6 @@
         "html"
       ],
       "thresholds": { "high": 90, "low": 60, "break": 60 }
+	"ignore-methods" : [ "ConfigureAwait" ]
     }  
   }


### PR DESCRIPTION
This PR updates the mock bot to persist all messages in memory, including messages received from Dmr. This will make it more testable.

Closes #32 

Closes #33 