### PR TITLE
Adding in CentOps integration - Dmr location now comes from CentOps

### DIFF
--- a/src/MockBot.Api/Controllers/ChatController.cs
+++ b/src/MockBot.Api/Controllers/ChatController.cs
@@ -1,10 +1,10 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Buerokratt.Common.AsyncProcessor;
+using Buerokratt.Common.Dmr;
+using Buerokratt.Common.Models;
+using Microsoft.AspNetCore.Mvc;
 using MockBot.Api.Configuration;
 using MockBot.Api.Interfaces;
 using MockBot.Api.Models;
-using RequestProcessor.AsyncProcessor;
-using RequestProcessor.Dmr;
-using RequestProcessor.Models;
 using System.Text;
 
 namespace MockBot.Api.Controllers

--- a/src/MockBot.Api/Controllers/DmrController.cs
+++ b/src/MockBot.Api/Controllers/DmrController.cs
@@ -1,9 +1,9 @@
+using Buerokratt.Common.Dmr;
+using Buerokratt.Common.Encoder;
+using Buerokratt.Common.Models;
 using Microsoft.AspNetCore.Mvc;
 using MockBot.Api.Controllers.Extensions;
 using MockBot.Api.Interfaces;
-using RequestProcessor.Dmr;
-using RequestProcessor.Models;
-using RequestProcessor.Services.Encoder;
 using System.Text;
 using System.Text.Json;
 

--- a/src/MockBot.Api/Interfaces/IChatService.cs
+++ b/src/MockBot.Api/Interfaces/IChatService.cs
@@ -1,5 +1,5 @@
-﻿using MockBot.Api.Models;
-using RequestProcessor.Models;
+﻿using Buerokratt.Common.Models;
+using MockBot.Api.Models;
 
 namespace MockBot.Api.Interfaces
 {

--- a/src/MockBot.Api/MockBot.Api.csproj
+++ b/src/MockBot.Api/MockBot.Api.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Buerokratt.Common" Version="1.0.53-prerelease" />
+    <PackageReference Include="Buerokratt.Common" Version="1.0.32" />
     <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/MockBot.Api/MockBot.Api.csproj
+++ b/src/MockBot.Api/MockBot.Api.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -13,12 +13,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Buerokratt.Common" Version="1.0.53-prerelease" />
     <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.15.1" />
-    <PackageReference Include="RequestProcessor" Version="1.0.29" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/src/MockBot.Api/Program.cs
+++ b/src/MockBot.Api/Program.cs
@@ -1,10 +1,11 @@
+using Buerokratt.Common.CentOps;
+using Buerokratt.Common.Dmr;
+using Buerokratt.Common.Dmr.Extensions;
+using Buerokratt.Common.Encoder;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using MockBot.Api.Configuration;
 using MockBot.Api.Interfaces;
 using MockBot.Api.Services;
-using MockBot.Api.Services.Dmr.Extensions;
-using RequestProcessor.Dmr;
-using RequestProcessor.Services.Encoder;
 using System.Diagnostics.CodeAnalysis;
 
 namespace MockBot.Api
@@ -23,7 +24,8 @@ namespace MockBot.Api
 
             // Add services to the container.
             var dmrSettings = configuration.GetSection("DmrServiceSettings").Get<DmrServiceSettings>();
-            services.AddDmrService(dmrSettings);
+            var centOpsSettings = configuration.GetSection("DmrServiceSettings").Get<CentOpsServiceSettings>();
+            services.AddDmrService(dmrSettings, centOpsSettings);
 
             var botSettings = configuration.GetSection("BotSettings").Get<BotSettings>();
             services.TryAddSingleton(botSettings);

--- a/src/MockBot.Api/Services/ChatService.cs
+++ b/src/MockBot.Api/Services/ChatService.cs
@@ -1,6 +1,6 @@
-﻿using MockBot.Api.Interfaces;
+﻿using Buerokratt.Common.Models;
+using MockBot.Api.Interfaces;
 using MockBot.Api.Models;
-using RequestProcessor.Models;
 using System.Collections.Concurrent;
 using Chat = MockBot.Api.Models.Chat;
 

--- a/src/MockBot.Api/appsettings.json
+++ b/src/MockBot.Api/appsettings.json
@@ -7,8 +7,8 @@
   },
   "AllowedHosts": "*",
   "DmrServiceSettings": {
-    "DmrApiUri": "https://tablelogapi.azurewebsites.net/app/frommockbot",
-    "DmrRequestProcessIntervalMs": 5000
+    "CentOpsUri": "http://127.0.0.1:8080",
+    "CentOpsApiKey": "<generate a key>"
   },
   "BotSettings": {
     "Id": "MockBot"

--- a/src/MockBot.UnitTests/Controllers/ChatControllerTests.cs
+++ b/src/MockBot.UnitTests/Controllers/ChatControllerTests.cs
@@ -1,3 +1,5 @@
+using Buerokratt.Common.AsyncProcessor;
+using Buerokratt.Common.Dmr;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using MockBot.Api.Configuration;
@@ -6,8 +8,6 @@ using MockBot.Api.Interfaces;
 using MockBot.Api.Models;
 using MockBot.Api.Services;
 using Moq;
-using RequestProcessor.AsyncProcessor;
-using RequestProcessor.Dmr;
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/MockBot.UnitTests/Controllers/DmrControllerTests.cs
+++ b/src/MockBot.UnitTests/Controllers/DmrControllerTests.cs
@@ -1,3 +1,5 @@
+using Buerokratt.Common.Encoder;
+using Buerokratt.Common.Models;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -5,8 +7,6 @@ using MockBot.Api.Controllers;
 using MockBot.Api.Interfaces;
 using MockBot.Api.Services;
 using Moq;
-using RequestProcessor.Models;
-using RequestProcessor.Services.Encoder;
 using System;
 using System.IO;
 using System.Text;

--- a/src/MockBot.UnitTests/Extensions/MockHttpMessageHandlerExtensions.cs
+++ b/src/MockBot.UnitTests/Extensions/MockHttpMessageHandlerExtensions.cs
@@ -1,5 +1,5 @@
-﻿using RequestProcessor.Dmr;
-using RequestProcessor.Services.Encoder;
+﻿using Buerokratt.Common.Dmr;
+using Buerokratt.Common.Encoder;
 using RichardSzalay.MockHttp;
 using System.Net;
 using System.Text.Json;

--- a/src/MockBot.UnitTests/MockBot.UnitTests.csproj
+++ b/src/MockBot.UnitTests/MockBot.UnitTests.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Buerokratt.Common" Version="1.0.53-prerelease" />
+    <PackageReference Include="Buerokratt.Common" Version="1.0.32" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Moq" Version="4.18.1" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />

--- a/src/MockBot.UnitTests/MockBot.UnitTests.csproj
+++ b/src/MockBot.UnitTests/MockBot.UnitTests.csproj
@@ -12,9 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Buerokratt.Common" Version="1.0.53-prerelease" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Moq" Version="4.18.1" />
-    <PackageReference Include="RequestProcessor" Version="1.0.29" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/src/MockBot.UnitTests/Services/ChatServiceTests.cs
+++ b/src/MockBot.UnitTests/Services/ChatServiceTests.cs
@@ -1,6 +1,6 @@
-﻿using MockBot.Api.Models;
+﻿using Buerokratt.Common.Models;
+using MockBot.Api.Models;
 using MockBot.Api.Services;
-using RequestProcessor.Models;
 using System;
 using Xunit;
 


### PR DESCRIPTION
- Mockbot now expects to talk to CentOps to get Dmr location.
- This means configuration to allow this to happen - e.g. a Participant for Mockbot needs to be created.
- This will affect integration tests.