### PR TITLE
Adding in an API key for ChatBot API

### DIFF
--- a/src/MockBot.Api/Controllers/DmrController.cs
+++ b/src/MockBot.Api/Controllers/DmrController.cs
@@ -1,6 +1,7 @@
 using Buerokratt.Common.Dmr;
 using Buerokratt.Common.Encoder;
 using Buerokratt.Common.Models;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using MockBot.Api.Controllers.Extensions;
 using MockBot.Api.Interfaces;
@@ -11,6 +12,7 @@ namespace MockBot.Api.Controllers
 {
     [Route("dmr-api")]
     [ApiController]
+    [AllowAnonymous]
     public class DmrController : ControllerBase
     {
         private readonly IChatService _chatService;

--- a/src/MockBot.Api/Controllers/Errors.cs
+++ b/src/MockBot.Api/Controllers/Errors.cs
@@ -1,5 +1,9 @@
-﻿namespace MockBot.Api.Controllers
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace MockBot.Api.Controllers
 {
+    // No logic so no unit tests are required
+    [ExcludeFromCodeCoverage]
     public static class Errors
     {
         public static readonly string PostNoBodyMessage = "Post must have a body";

--- a/src/MockBot.Api/MockBot.Api.csproj
+++ b/src/MockBot.Api/MockBot.Api.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="AspNetCore.Authentication.ApiKey" Version="6.0.1" />
-    <PackageReference Include="Buerokratt.Common" Version="1.0.32" />
+    <PackageReference Include="Buerokratt.Common" Version="1.0.33" />
     <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/MockBot.Api/MockBot.Api.csproj
+++ b/src/MockBot.Api/MockBot.Api.csproj
@@ -13,6 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AspNetCore.Authentication.ApiKey" Version="6.0.1" />
     <PackageReference Include="Buerokratt.Common" Version="1.0.32" />
     <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>

--- a/src/MockBot.Api/Program.cs
+++ b/src/MockBot.Api/Program.cs
@@ -1,7 +1,9 @@
+using AspNetCore.Authentication.ApiKey;
 using Buerokratt.Common.CentOps;
 using Buerokratt.Common.Dmr;
 using Buerokratt.Common.Dmr.Extensions;
 using Buerokratt.Common.Encoder;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using MockBot.Api.Configuration;
 using MockBot.Api.Interfaces;
@@ -22,13 +24,11 @@ namespace MockBot.Api
 
             _ = configuration.AddEnvironmentVariables();
 
-            // Add services to the container.
-            var dmrSettings = configuration.GetSection("DmrServiceSettings").Get<DmrServiceSettings>();
-            var centOpsSettings = configuration.GetSection("DmrServiceSettings").Get<CentOpsServiceSettings>();
-            services.AddDmrService(dmrSettings, centOpsSettings);
-
             var botSettings = configuration.GetSection("BotSettings").Get<BotSettings>();
             services.TryAddSingleton(botSettings);
+
+            services.AddDmrCommunications(configuration);
+            services.AddApiAuthentication(configuration);
 
             _ = services.AddControllers();
             // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
@@ -50,6 +50,7 @@ namespace MockBot.Api
 
             _ = app.UseHttpsRedirection();
 
+            _ = app.UseAuthentication();
             _ = app.UseAuthorization();
 
             _ = app.MapControllers();

--- a/src/MockBot.Api/Program.cs
+++ b/src/MockBot.Api/Program.cs
@@ -1,9 +1,4 @@
-using AspNetCore.Authentication.ApiKey;
-using Buerokratt.Common.CentOps;
-using Buerokratt.Common.Dmr;
-using Buerokratt.Common.Dmr.Extensions;
 using Buerokratt.Common.Encoder;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using MockBot.Api.Configuration;
 using MockBot.Api.Interfaces;

--- a/src/MockBot.Api/ProgramHelpers.cs
+++ b/src/MockBot.Api/ProgramHelpers.cs
@@ -1,0 +1,63 @@
+﻿using AspNetCore.Authentication.ApiKey;
+using Buerokratt.Common.CentOps;
+using Buerokratt.Common.Dmr;
+using Buerokratt.Common.Dmr.Extensions;
+using Microsoft.AspNetCore.Authorization;
+
+namespace MockBot.Api
+{
+    internal static class ServiceCollectionExtensions
+    {
+
+        public static void AddDmrCommunications(this IServiceCollection services, ConfigurationManager configuration)
+        {
+            // Add services to the container.
+            var configurationSectionName = "DmrServiceSettings";
+            var dmrSettings = configuration.GetSection(configurationSectionName).Get<DmrServiceSettings>();
+            var centOpsSettings = configuration.GetSection(configurationSectionName).Get<CentOpsServiceSettings>();
+            services.AddDmrService(dmrSettings, centOpsSettings);
+        }
+
+        public static void AddApiAuthentication(this IServiceCollection services, ConfigurationManager configuration)
+        {
+            var configuredApiKey = configuration.GetConnectionString("ApiKey");
+            if (string.IsNullOrWhiteSpace(configuredApiKey))
+            {
+                throw new ArgumentException("ConnectionString::ApiKey not specified.");
+            }
+
+            _ = services.AddAuthentication(ApiKeyDefaults.AuthenticationScheme)
+                        .AddApiKeyInHeader(options =>
+                        {
+                            options.KeyName = "X-Api-Key";
+                            options.Realm = "Mockbot";
+                            options.IgnoreAuthenticationIfAllowAnonymous = true;
+                            options.Events = new ApiKeyEvents
+                            {
+                                OnValidateKey = context =>
+                                {
+                                    if (string.IsNullOrEmpty(context.ApiKey) ||
+                                        context.ApiKey != configuredApiKey)
+                                    {
+                                        context.ValidationFailed();
+
+                                    }
+                                    else
+                                    {
+                                        context.ValidationSucceeded();
+                                    }
+
+                                    return Task.CompletedTask;
+                                }
+                            };
+                        });
+
+            _ = services.AddAuthorization(options =>
+            {
+                options.FallbackPolicy = new AuthorizationPolicyBuilder()
+                    .RequireAuthenticatedUser()
+                    .Build();
+            });
+        }
+    }
+}

--- a/src/MockBot.Api/ServiceCollectionExtensions.cs
+++ b/src/MockBot.Api/ServiceCollectionExtensions.cs
@@ -49,7 +49,6 @@ namespace MockBot.Api
                                         context.ApiKey != configuredApiKey)
                                     {
                                         context.ValidationFailed();
-
                                     }
                                     else
                                     {

--- a/src/MockBot.Api/ServiceCollectionExtensions.cs
+++ b/src/MockBot.Api/ServiceCollectionExtensions.cs
@@ -6,11 +6,15 @@ using Microsoft.AspNetCore.Authorization;
 
 namespace MockBot.Api
 {
-    internal static class ServiceCollectionExtensions
+    public static class ServiceCollectionExtensions
     {
-
-        public static void AddDmrCommunications(this IServiceCollection services, ConfigurationManager configuration)
+        public static void AddDmrCommunications(this IServiceCollection services, IConfiguration configuration)
         {
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
             // Add services to the container.
             var configurationSectionName = "DmrServiceSettings";
             var dmrSettings = configuration.GetSection(configurationSectionName).Get<DmrServiceSettings>();
@@ -18,12 +22,17 @@ namespace MockBot.Api
             services.AddDmrService(dmrSettings, centOpsSettings);
         }
 
-        public static void AddApiAuthentication(this IServiceCollection services, ConfigurationManager configuration)
+        public static void AddApiAuthentication(this IServiceCollection services, IConfiguration configuration)
         {
+            if (configuration == null)
+            {
+                throw new ArgumentNullException(nameof(configuration));
+            }
+
             var configuredApiKey = configuration.GetConnectionString("ApiKey");
             if (string.IsNullOrWhiteSpace(configuredApiKey))
             {
-                throw new ArgumentException("ConnectionString::ApiKey not specified.");
+                throw new ArgumentException("ConnectionStrings::ApiKey not specified.");
             }
 
             _ = services.AddAuthentication(ApiKeyDefaults.AuthenticationScheme)

--- a/src/MockBot.Api/appsettings.json
+++ b/src/MockBot.Api/appsettings.json
@@ -14,6 +14,6 @@
     "Id": "MockBot"
   },
   "ConnectionStrings": {
-    "ApiKey": "cheese"
+    "ApiKey": "<generate a key>"
   }
 }

--- a/src/MockBot.Api/appsettings.json
+++ b/src/MockBot.Api/appsettings.json
@@ -12,5 +12,8 @@
   },
   "BotSettings": {
     "Id": "MockBot"
+  },
+  "ConnectionStrings": {
+    "ApiKey": "cheese"
   }
 }

--- a/src/MockBot.UnitTests/Controllers/ChatControllerTests.cs
+++ b/src/MockBot.UnitTests/Controllers/ChatControllerTests.cs
@@ -100,6 +100,9 @@ namespace MockBot.UnitTests.Controllers
             Assert.Equal($"/chats/{chat.Id}/messages", createdResult.Location);
             Assert.NotEmpty(resultMessage.Id.ToString());
             Assert.True(currentDateTime < resultMessage.CreatedAt);
+
+            // Validate the payload which is sent as a result of the message content.
+            _mockDmrService.Verify(dmr => dmr.Enqueue(It.Is<DmrRequest>(d => d.Payload.Message == payload)), Times.Exactly(1));
         }
 
         [Fact]

--- a/src/MockBot.UnitTests/Extensions/ServiceCollectionExtensionTests.cs
+++ b/src/MockBot.UnitTests/Extensions/ServiceCollectionExtensionTests.cs
@@ -1,0 +1,110 @@
+﻿using AspNetCore.Authentication.ApiKey;
+using Buerokratt.Common.CentOps;
+using Buerokratt.Common.CentOps.Interfaces;
+using Buerokratt.Common.Dmr;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using MockBot.Api;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace MockBot.UnitTests.Extensions
+{
+    public class ServiceCollectionExtensionTests
+    {
+        [Fact]
+        public void AddDmrCommunicationsThrowsForMissingConfiguration()
+        {
+            // Arrange
+            IServiceCollection services = new ServiceCollection();
+
+            // Act & Assert
+            _ = Assert.Throws<ArgumentNullException>(() => services.AddDmrCommunications(null));
+        }
+
+        [Fact]
+        public void AddDmrCommunicationsAddsCorrectTypes()
+        {
+            // Arrange
+            IServiceCollection services = new ServiceCollection();
+
+            var inMemorySettings = new Dictionary<string, string> {
+                {"DmrServiceSettings:CentOpsApiKey", "value"},
+                {"DmrServiceSettings:CentOpsUrl", "value"},
+            };
+
+            IConfiguration configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(inMemorySettings)
+                .Build();
+
+            // Act
+            services.AddDmrCommunications(configuration);
+
+            // Assert
+            // Ensure that there's an ICentOpsService Implementation otherwise code needs to change.
+            var interfaces = services.Select(s => s.ServiceType).ToArray();
+            _ = interfaces.Should().Contain(typeof(ICentOpsService));
+        }
+
+        [Fact]
+        public void AddApiAuthenticationThrowsForMissingConfiguration()
+        {
+            // Arrange
+            IServiceCollection services = new ServiceCollection();
+
+            // Act & Assert
+            _ = Assert.Throws<ArgumentNullException>(() => services.AddApiAuthentication(null));
+        }
+
+        [Fact]
+        public void AddApiAuthenticationForMissingApiKeyConfig()
+        {
+            // Arrange
+            IServiceCollection services = new ServiceCollection();
+
+            var inMemorySettings = new Dictionary<string, string> {
+                {"DmrServiceSettings:CentOpsApiKey", "value"},
+                {"DmrServiceSettings:CentOpsUrl", "value"},
+                {"ConnectionStrings:ApiKey", string.Empty},
+            };
+
+            IConfiguration configuration = new ConfigurationBuilder()
+               .AddInMemoryCollection(inMemorySettings)
+               .Build();
+
+            // Act & Assert
+            _ = Assert.Throws<ArgumentException>(() => services.AddApiAuthentication(configuration));
+        }
+
+
+        [Fact]
+        public void AddApiAuthenticationAddsCorrectTypes()
+        {
+            // Arrange
+            IServiceCollection services = new ServiceCollection();
+
+            var inMemorySettings = new Dictionary<string, string> {
+                {"DmrServiceSettings:CentOpsApiKey", "value"},
+                {"DmrServiceSettings:CentOpsUrl", "value"},
+                {"ConnectionStrings:ApiKey", "key"},
+            };
+
+            IConfiguration configuration = new ConfigurationBuilder()
+               .AddInMemoryCollection(inMemorySettings)
+               .Build();
+
+            // Act
+            services.AddApiAuthentication(configuration);
+
+            // Assert
+            // Assert
+            // Ensure that there's an ICentOpsService Implementation otherwise code needs to change.
+            var interfaces = services.Select(s => s.ServiceType).ToArray();
+            _ = interfaces.Should().Contain(typeof(ApiKeyInHeaderHandler));
+        }
+    }
+}

--- a/src/MockBot.UnitTests/Extensions/ServiceCollectionExtensionTests.cs
+++ b/src/MockBot.UnitTests/Extensions/ServiceCollectionExtensionTests.cs
@@ -1,12 +1,9 @@
 ﻿using AspNetCore.Authentication.ApiKey;
-using Buerokratt.Common.CentOps;
 using Buerokratt.Common.CentOps.Interfaces;
-using Buerokratt.Common.Dmr;
 using FluentAssertions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using MockBot.Api;
-using Moq;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/MockBot.UnitTests/Extensions/ServiceCollectionExtensionTests.cs
+++ b/src/MockBot.UnitTests/Extensions/ServiceCollectionExtensionTests.cs
@@ -98,7 +98,6 @@ namespace MockBot.UnitTests.Extensions
             services.AddApiAuthentication(configuration);
 
             // Assert
-            // Ensure that there's an ICentOpsService Implementation otherwise code needs to change.
             var interfaces = services.Select(s => s.ServiceType).ToArray();
             _ = interfaces.Should().Contain(typeof(ApiKeyInHeaderHandler));
         }

--- a/src/MockBot.UnitTests/MockBot.UnitTests.csproj
+++ b/src/MockBot.UnitTests/MockBot.UnitTests.csproj
@@ -12,9 +12,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Buerokratt.Common" Version="1.0.32" />
+    <PackageReference Include="Buerokratt.Common" Version="1.0.33" />
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="MockLogging" Version="0.1.8" />
     <PackageReference Include="Moq" Version="4.18.1" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/MockBot.UnitTests/MockBot.UnitTests.csproj
+++ b/src/MockBot.UnitTests/MockBot.UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Buerokratt.Common" Version="1.0.32" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Moq" Version="4.18.1" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />


### PR DESCRIPTION
This is protecting the Chat API (which would need to be called from outside of the cluster). 
The dmr-api/messages endpoint should be protected by networking to ensure it's not callable outside of the cluster.  (We need to do this, but it needs to remain anonymous at the moment)
I've got a separate change to update the Integration tests.